### PR TITLE
Fix `storageClassName` in generated PV example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ spec:
   - tls
   - iam
   persistentVolumeReclaimPolicy: Delete
-  storageClassName: efs
+  storageClassName: efs-sc
   volumeMode: Filesystem
 status:
   phase: Bound


### PR DESCRIPTION
I was confused by the example, because it appeared to create a PV for _itself_, rather than for the EFS CSI Driver.

Looking at [the source](https://github.com/LogMeIn/aws-efs-csi-pv-provisioner/blob/dea23c41da6b2afb068952d01ab3016ef662ae3b/aws-efs-csi-pv-provisioner.go#L85), it appears that the generated PV's `storageClassName` is `efs-sc` (for the EFS CSI Driver), not `efs` (for this CSI Driver).

Signed-off-by: Paul "Hampy" Hampson <p_hampson@wargaming.net>